### PR TITLE
Prevent changing /var/log and /var/run ownership and permissions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nacer.laradji@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Zabbix Agent/Server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.8.0'
+version '0.8.1'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nacer.laradji@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Zabbix Agent/Server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.8.1'
+version '0.8.0'
 supports 'ubuntu', '>= 10.04'
 supports 'debian', '>= 6.0'
 supports 'redhat', '>= 5.0'

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -48,7 +48,7 @@ zabbix_dirs.each do |dir|
     recursive true
     # Only execute this if zabbix can't write to it. This handles cases of
     # dir being world writable (like /tmp)
-    not_if { ::File.world_writable?(dir) }
+    not_if { ::File.world_writable?(dir) || ["/var/log", "/var/run"].include?(dir) }
   end
 end
 


### PR DESCRIPTION
When specifying `log_dir` = /var/log, the recipe changes ownership of
the dir to zabbix. Same happens with /var/run

This patch prevents that.